### PR TITLE
Fix negative coordinate column wrapping

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -50,7 +50,7 @@
                 wrappedColumn;
 
             if (coord.column < 0) {
-                wrappedColumn = (coord.column + columnSize) % columnSize;
+                wrappedColumn = ((coord.column % columnSize) + columnSize) % columnSize;
             } else {
                 wrappedColumn = coord.column % columnSize;
             }


### PR DESCRIPTION
When panning west, past coordinate column -4, the coordinate column would be wrapped incorrectly causing tiles to not show. For example, column -5 was wrapped to -1, when it should have been wrapped to 3.

This fixes mapbox/tilemill#1395
