### PR TITLE
Tile size fix

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -302,7 +302,8 @@
             // Start tile positioning and prevent drag for modern browsers
             tile.style.cssText = 'position:absolute;-webkit-user-select:none;' +
                 '-webkit-user-drag:none;-moz-user-drag:none;-webkit-transform-origin:0 0;' +
-                '-moz-transform-origin:0 0;-o-transform-origin:0 0;-ms-transform-origin:0 0;';
+                '-moz-transform-origin:0 0;-o-transform-origin:0 0;-ms-transform-origin:0 0;' +
+                'width:' + this.map.tileSize.x + 'px; height: ' + this.map.tileSize.y + 'px;';
 
             // Prevent drag for IE
             tile.ondragstart = function() { return false; };


### PR DESCRIPTION
port of fix by @kkaefer tileSize fix to modestmaps/ organization repo. This is a patch-bug-fix that correctly scales tiles when you request a larger or smaller tilesize

This would push the repo to 3.1.3 if the other pull req is accepted first.

/cc @migurski @shawnbot 
