### PR TITLE
Add support for named layers

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -1,8 +1,9 @@
 
     // Layer
-    MM.Layer = function(provider, parent) {
+    MM.Layer = function(provider, parent, name) {
         this.parent = parent || document.createElement('div');
         this.parent.style.cssText = 'position: absolute; top: 0px; left: 0px; width: 100%; height: 100%; margin: 0; padding: 0; z-index: 0';
+        this.name = name;
         this.levels = {};
         this.requestManager = new MM.RequestManager();
         this.requestManager.addCallback('requestcomplete', this.getTileComplete());
@@ -14,6 +15,7 @@
 
         map: null, // TODO: remove
         parent: null,
+        name: null,
         tiles: null,
         levels: null,
         requestManager: null,

--- a/src/map.js
+++ b/src/map.js
@@ -400,6 +400,14 @@
             return this.layers.slice();
         },
 
+        // return the first layer with given name
+        getLayer: function(name) {
+            for (var i = 0; i < this.layers.length; i++) {
+                if (name == this.layers[i].name)
+                    return this.layers[i];
+            }
+        },
+
         // return the layer at the given index
         getLayerAt: function(index) {
             return this.layers[index];
@@ -422,7 +430,7 @@
         // find the given layer and remove it
         removeLayer: function(layer) {
             for (var i = 0; i < this.layers.length; i++) {
-                if (layer == this.layers[i]) {
+                if (layer == this.layers[i] || layer == this.layers[i].name) {
                     this.removeLayerAt(i);
                     break;
                 }

--- a/src/provider.js
+++ b/src/provider.js
@@ -144,6 +144,6 @@
 
     MM.extend(MM.Template, MM.MapProvider);
 
-    MM.TemplatedLayer = function(template, subdomains) {
-      return new MM.Layer(new MM.Template(template, subdomains));
+    MM.TemplatedLayer = function(template, subdomains, name) {
+      return new MM.Layer(new MM.Template(template, subdomains), null, name);
     };

--- a/test/browser/spec/Map.js
+++ b/test/browser/spec/Map.js
@@ -228,6 +228,21 @@ describe('Map', function() {
 
           expect(map.getLayers().length).toEqual(1);
       });
+
+      it('Can set and get a named layer', function() {
+          var l = new MM.TemplatedLayer(
+              'http://{S}.tile.openstreetmap.org/{Z}/{X}/{Y}.png', ['a'], 'name');
+          map.addLayer(l);
+          expect(map.getLayer('name')).toEqual(l);
+      });
+
+      it('Can remove a named layer', function() {
+          var l = new MM.TemplatedLayer(
+              'http://{S}.tile.openstreetmap.org/{Z}/{X}/{Y}.png', ['a'], 'name');
+          map.addLayer(l);
+          var numLayers = map.getLayers().length;
+          expect(map.removeLayer('name').getLayers().length).toEqual(numLayers - 1);
+      });
   });
 
   it('can transform an extent into a coord', function() {


### PR DESCRIPTION
- Adds name as a third argument when creating layers.
- Adds `map.getLayer(name)`
- Adds support for removing by name to `map.removeLayer()`

Relevant issue: #25
