### PR TITLE
Add ability to enable/disable layers

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -16,6 +16,7 @@
         map: null, // TODO: remove
         parent: null,
         name: null,
+        enabled: true,
         tiles: null,
         levels: null,
         requestManager: null,
@@ -47,6 +48,7 @@
         },
 
         draw: function() {
+            if (!this.enabled) return;
             // compares manhattan distance from center of
             // requested tiles to current map center
             // NB:- requested tiles are *popped* from queue, so we do a descending sort
@@ -400,12 +402,26 @@
             }
         },
 
+        // Enable a layer and show its dom element
+        enable: function() {
+            this.enabled = true;
+            this.parent.style.display = '';
+            this.draw();
+        },
+
+        // Disable a layer, don't display in DOM, clear all requests
+        disable: function() {
+            this.enabled = false;
+            this.requestManager.clear();
+            this.parent.style.display = 'none';
+        },
+
 
         // Remove this layer from the DOM, cancel all of its requests
         // and unbind any callbacks that are bound to it.
         destroy: function() {
-            this.requestManager.clear();
             this.requestManager.removeCallback('requestcomplete', this.getTileComplete());
+            this.requestManager.addCallback('requesterror', this.getTileError());
             // TODO: does requestManager need a destroy function too?
             this.provider = null;
             // If this layer was ever attached to the DOM, detach it.

--- a/src/map.js
+++ b/src/map.js
@@ -532,6 +532,30 @@
             return this;
         },
 
+        // Enable and disable layers.
+        // Disabled layers are not displayed, are not drawn, and do not request
+        // tiles. They do maintain their layer index on the map.
+        enableLayer: function(name) {
+            this.getLayer(name).enable();
+            return this;
+        },
+
+        enableLayerAt: function(index) {
+            this.getLayerAt(index).enable();
+            return this;
+        },
+
+        disableLayer: function(name) {
+            this.getLayer(name).disable();
+            return this;
+        },
+
+        disableLayerAt: function(index) {
+            this.getLayerAt(index).disable();
+            return this;
+        },
+
+
         // limits
 
         enforceZoomLimits: function(coord) {

--- a/src/map.js
+++ b/src/map.js
@@ -536,22 +536,26 @@
         // Disabled layers are not displayed, are not drawn, and do not request
         // tiles. They do maintain their layer index on the map.
         enableLayer: function(name) {
-            this.getLayer(name).enable();
+            var l = this.getLayer(name);
+            if (l) l.enable();
             return this;
         },
 
         enableLayerAt: function(index) {
-            this.getLayerAt(index).enable();
+            var l = this.getLayerAt(index);
+            if (l) l.enable();
             return this;
         },
 
         disableLayer: function(name) {
-            this.getLayer(name).disable();
+            var l = this.getLayer(name);
+            if (l) l.disable();
             return this;
         },
 
         disableLayerAt: function(index) {
-            this.getLayerAt(index).disable();
+            var l = this.getLayerAt(index);
+            if (l) l.disable();
             return this;
         },
 

--- a/test/browser/spec/Map.js
+++ b/test/browser/spec/Map.js
@@ -243,6 +243,26 @@ describe('Map', function() {
           var numLayers = map.getLayers().length;
           expect(map.removeLayer('name').getLayers().length).toEqual(numLayers - 1);
       });
+
+      it('Can disable and enable a layer by index', function() {
+          map.disableLayerAt(0);
+          expect(map.getLayerAt(0).enabled).toEqual(false);
+          expect(map.getLayerAt(0).parent.style.display).toEqual('none');
+          map.enableLayerAt(0);
+          expect(map.getLayerAt(0).enabled).toEqual(true);
+          expect(map.getLayerAt(0).parent.style.display).not.toEqual('none');
+      });
+
+      it('Can disable and enable a layer by name', function() {
+          var l = new MM.TemplatedLayer(
+              'http://{S}.tile.openstreetmap.org/{Z}/{X}/{Y}.png', ['a'], 'name');
+          map.addLayer(l).disableLayer('name');
+          expect(map.getLayer('name').enabled).toEqual(false);
+          expect(map.getLayer('name').parent.style.display).toEqual('none');
+          map.enableLayerAt(1);
+          expect(map.getLayer('name').enabled).toEqual(true);
+          expect(map.getLayer('name').parent.style.display).not.toEqual('none');
+      });
   });
 
   it('can transform an extent into a coord', function() {


### PR DESCRIPTION
Layers can be disabled, which prevents them from being drawn and requesting tiles. It greatly simplifies the process of switching layers on and off while maintaining layer order.

Relevant issue is #26
