### PR TITLE
Fix rounding bug in sourceCoordinate

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,9 @@ Following the semantic versioning recommendation best we can:
     minor version, and backwards incompatible API changes increment
     the major version." -- http://semver.org/
 
+v3.3.5
+- Fixes rounding bug in MapProvider's `sourceCoordinate`
+
 v3.3.4
 - Layers no longer copy their CSS properties from their parent nodes,
   so that parent node CSS can be changed with properties like `clip` and

--- a/src/provider.js
+++ b/src/provider.js
@@ -43,9 +43,11 @@
         // return null if wrapped coordinate is outside of the tile limits
         sourceCoordinate: function(coord) {
             var TL = this.tileLimits[0].zoomTo(coord.zoom).container(),
-                BR = this.tileLimits[1].zoomTo(coord.zoom).container().right().down(),
+                BR = this.tileLimits[1].zoomTo(coord.zoom),
                 columnSize = Math.pow(2, coord.zoom),
                 wrappedColumn;
+
+            BR = new MM.Coordinate(Math.ceil(BR.row), Math.ceil(BR.column), Math.floor(BR.zoom));
 
             if (coord.column < 0) {
                 wrappedColumn = ((coord.column % columnSize) + columnSize) % columnSize;


### PR DESCRIPTION
sourceCoordinate would run into problems when the the bottom right tileLimit was a perfectly round coordinate. It would get rounded up by a whole coordinate, causing requests for invalid tiles.

`.container().right().down()` was essentially doing `floor(BR) + 1` when what we really want is `ceil(BR)`

/cc @tmcw 
