### PR TITLE
Fixing typo in examples that use modestmaps.markers.js

### DIFF
--- a/examples/geojson/modestmaps.markers.js
+++ b/examples/geojson/modestmaps.markers.js
@@ -187,7 +187,7 @@ if (!com.modestmaps) {
                 // offset by the layer parent position if x or y is non-zero
                 if (this.position.x || this.position.y) {
                     pos.x -= this.position.x;
-                    pox.y -= this.position.y;
+                    pos.y -= this.position.y;
                 }
                 marker.style.left = ~~(pos.x + .5) + "px";
                 marker.style.top = ~~(pos.y + .5) + "px";

--- a/examples/spotlight/modestmaps.markers.js
+++ b/examples/spotlight/modestmaps.markers.js
@@ -187,7 +187,7 @@ if (!com.modestmaps) {
                 // offset by the layer parent position if x or y is non-zero
                 if (this.position.x || this.position.y) {
                     pos.x -= this.position.x;
-                    pox.y -= this.position.y;
+                    pos.y -= this.position.y;
                 }
                 marker.style.left = ~~(pos.x + .5) + "px";
                 marker.style.top = ~~(pos.y + .5) + "px";


### PR DESCRIPTION
Two examples (geojson and spotlight) use a old version of what eventually became mmg/markers.js/mapbox.js markers api. This fixes a typo in those examples that was throwing some errors.
