### PR TITLE
Fix off-by-one error

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -96,9 +96,9 @@
             var tileCoord = startCoord.copy();
 
             for (tileCoord.column = startCoord.column;
-                 tileCoord.column <= endCoord.column; tileCoord.column++) {
+                 tileCoord.column < endCoord.column; tileCoord.column++) {
                 for (tileCoord.row = startCoord.row;
-                     tileCoord.row <= endCoord.row; tileCoord.row++) {
+                     tileCoord.row < endCoord.row; tileCoord.row++) {
                     var validKeys = this.inventoryVisibleTile(levelElement, tileCoord);
 
                     while (validKeys.length) {

--- a/test/spec/Layer.js
+++ b/test/spec/Layer.js
@@ -10,6 +10,23 @@ describe('Layer', function() {
         expect(l.map).toEqual(null);
     });
 
+    it('should not request more tiles than needed', function () {
+        var p, requested = {};
+        runs(function() {
+            p = new MM.TemplatedLayer('http://tile.openstreetmap.org/{Z}/{X}/{Y}.png');
+            p.requestManager.requestTile = function (key) {
+                requested[key] = true;
+            };
+            var m = new MM.Map(document.createElement('div'), p, { x: 1, y: 1 });
+            var coord = new MM.Coordinate(0.5, 0.5, 1);
+            m.setCenter(m.coordinateLocation(coord)).setZoom(1);
+        });
+        waits(500);
+        runs(function() {
+            expect(requested).toEqual({'1,0,0': true});
+        });
+    });
+
     // Currently not testing subdomain-based templatedmapprovider, since
     // the implementation should be kind of undefined.
     it('causes the map to throw requesterror when things are not accessible', function() {


### PR DESCRIPTION
Just assume we have a 1x1 viewport for which startCoord is 0/0 and endcoord will
be rounded up to 1/1.
Using <= would result in loading 4 tiles which is obviously not what we want
for a 1x1 viewport.
