### PR TITLE
Template {subdomains} should be {subdomain} for Microsoft maps

### DIFF
--- a/src/provider.js
+++ b/src/provider.js
@@ -92,7 +92,7 @@
         var isQuadKey = template.match(/{(Q|quadkey)}/);
         // replace Microsoft style substitution strings
         if (isQuadKey) template = template
-            .replace('{subdomains}', '{S}')
+            .replace('{subdomain}', '{S}')
             .replace('{zoom}', '{Z}')
             .replace('{quadkey}', '{Q}');
 


### PR DESCRIPTION
The Template provider supports Microsoft-style URL templates, but it tries to search and replace `{subdomains}` when Microsoft uses instead `{subdomain}` in their template: http://msdn.microsoft.com/en-us/library/ff701716.aspx
