### PR TITLE
Load new tiles in the correct position

### DIFF
--- a/src/layer.js
+++ b/src/layer.js
@@ -1,4 +1,3 @@
-
     // Layer
     MM.Layer = function(provider, parent, name) {
         this.parent = parent || document.createElement('div');
@@ -319,9 +318,9 @@
 
             MM.moveElement(tile, {
                 x: Math.round((this.map.dimensions.x* 0.5) +
-                    (tile.coord.column - theCoord.column) * this.map.tileSize.x),
+                    (tile.coord.column - theCoord.column) * this.map.tileSize.x * scale),
                 y: Math.round((this.map.dimensions.y* 0.5) +
-                    (tile.coord.row - theCoord.row) * this.map.tileSize.y),
+                    (tile.coord.row - theCoord.row) * this.map.tileSize.y * scale),
                 scale: scale,
                 // TODO: pass only scale or only w/h
                 width: this.map.tileSize.x,


### PR DESCRIPTION
`MM.moveElement` in `MM.Layer.positionTile()` did not take account of the scale when setting the tile position. This is a problem when loading new tiles at non-integer zooms: tiles load first out of position, and then "jump" to the correct position when `MM.Layer.adjustVisibleLevel()` is called (which correctly includes the scale in the position calculation for `MM.moveElement`).

This change basically makes the `MM.moveElement` call in `MM.Layer.positionTile()` the same as that in `MM.Layer.adjustVisibleLevel()`. Makes for a much smoother experience when using the [easey library](https://www.mapbox.com/easey/) and zooming the map.
